### PR TITLE
2025/03/14 12:13 安田伊織

### DIFF
--- a/Assets/Project/Scenes/MainScene.unity
+++ b/Assets/Project/Scenes/MainScene.unity
@@ -6144,10 +6144,10 @@ PrefabInstance:
     - target: {fileID: 506543896210513844, guid: 3782b4cc6f05602409312a42382c747b, type: 3}
       propertyPath: m_ActionEvents.Array.data[10].m_PersistentCalls.m_Calls.Array.data[0].m_Target
       value: 
-      objectReference: {fileID: 1333169264}
+      objectReference: {fileID: 732653404}
     - target: {fileID: 506543896210513844, guid: 3782b4cc6f05602409312a42382c747b, type: 3}
       propertyPath: m_ActionEvents.Array.data[10].m_PersistentCalls.m_Calls.Array.data[0].m_MethodName
-      value: OnPausu
+      value: OnPause
       objectReference: {fileID: 0}
     - target: {fileID: 506543896210513844, guid: 3782b4cc6f05602409312a42382c747b, type: 3}
       propertyPath: m_ActionEvents.Array.data[10].m_PersistentCalls.m_Calls.Array.data[0].m_TargetAssemblyTypeName
@@ -6850,7 +6850,8 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    m_RemovedComponents: []
+    m_RemovedComponents:
+    - {fileID: 1238605832036620193, guid: 0824162a52a74704c9a39d5af1527554, type: 3}
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents: []
@@ -7244,6 +7245,7 @@ GameObject:
   m_Component:
   - component: {fileID: 732653403}
   - component: {fileID: 732653402}
+  - component: {fileID: 732653404}
   m_Layer: 0
   m_Name: MainAdmin
   m_TagString: Untagged
@@ -7290,6 +7292,19 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &732653404
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 732653401}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 2a517581a6e60904abbebdc57a81374e, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  Canvas: {fileID: 0}
 --- !u!1001 &744301564
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -13500,17 +13515,6 @@ MonoBehaviour:
   _sceneName: TitleScene
   _seNumber: 1
   Canvas: {fileID: 0}
---- !u!114 &1333169264 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 7709410441404712890, guid: 0824162a52a74704c9a39d5af1527554, type: 3}
-  m_PrefabInstance: {fileID: 498696224}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 2a517581a6e60904abbebdc57a81374e, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!1 &1333658501
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Project/Scenes/SceneTest/IoriTest/Manager.prefab
+++ b/Assets/Project/Scenes/SceneTest/IoriTest/Manager.prefab
@@ -13,7 +13,7 @@ GameObject:
   - component: {fileID: 7556316973918701959}
   - component: {fileID: 428016393658043902}
   - component: {fileID: 7864623128911793347}
-  - component: {fileID: 7709410441404712890}
+  - component: {fileID: 1238605832036620193}
   m_Layer: 0
   m_Name: Manager
   m_TagString: Untagged
@@ -284,7 +284,7 @@ AudioSource:
     m_PreInfinity: 2
     m_PostInfinity: 2
     m_RotationOrder: 4
---- !u!114 &7709410441404712890
+--- !u!114 &1238605832036620193
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}

--- a/Assets/Project/Script/InputSystem_Actions.inputactions
+++ b/Assets/Project/Script/InputSystem_Actions.inputactions
@@ -96,7 +96,7 @@
                     "initialStateCheck": false
                 },
                 {
-                    "name": "Puasu",
+                    "name": "Pause",
                     "type": "Button",
                     "id": "18bdd743-b822-46c3-9b6d-db4171c0f322",
                     "expectedControlType": "",
@@ -685,7 +685,7 @@
                     "interactions": "",
                     "processors": "",
                     "groups": ";Gamepad",
-                    "action": "Puasu",
+                    "action": "Pause",
                     "isComposite": false,
                     "isPartOfComposite": false
                 },
@@ -696,7 +696,7 @@
                     "interactions": "",
                     "processors": "",
                     "groups": ";Gamepad",
-                    "action": "Puasu",
+                    "action": "Pause",
                     "isComposite": false,
                     "isPartOfComposite": false
                 },
@@ -707,7 +707,7 @@
                     "interactions": "",
                     "processors": "",
                     "groups": ";Keyboard&Mouse",
-                    "action": "Puasu",
+                    "action": "Pause",
                     "isComposite": false,
                     "isPartOfComposite": false
                 }

--- a/Assets/Project/Script/MainScene/PauseManager.cs
+++ b/Assets/Project/Script/MainScene/PauseManager.cs
@@ -5,38 +5,27 @@ using UnityEngine.SceneManagement;
 
 public class PauseManager : MonoBehaviour
 {
-    public static PauseManager Instance;
+    private static PauseManager Instance;
+    public static PauseManager GetInstance()
+    {
+        return Instance;
+    }
     
     public GameObject Canvas;
+
+    private PlayerInput playerInput;
 
     private int BuildIndex;
 
     private bool IsPaused = false;
 
-
-    #region シングルトン
-
-    public static PauseManager GetInstance()
+    void Awake()
     {
-        if (Instance == null)
-        {
-            Instance = FindObjectOfType<PauseManager>();
-        }
-        return Instance;
-    }
-    private void Awake()
-    {
+        Instance = this;
+
         BuildIndex = SceneManager.GetActiveScene().buildIndex;
-        
-        if (this != GetInstance())
-        {
-            Destroy(this.gameObject);
-            return;
-        }
-        DontDestroyOnLoad(this.gameObject);
-
     }
-    #endregion
+
 
     #region Sceneを移動したときの処理
     private void OnEnable()
@@ -60,12 +49,41 @@ public class PauseManager : MonoBehaviour
                 Canvas = GameObject.Find("Canvas");  //Canvasを取得
                 Canvas.SetActive(false);  //取得してから非アクティブに変更
             }
+
+            GameObject player = GameObject.FindWithTag("Player");
+            if(player != null)
+            {
+                PlayerInput newplayerInput = player.GetComponent<PlayerInput>();
+                if(newplayerInput != null)
+                {
+                       
+                }
+            }
+        }
+    }
+
+    public void RegisterPlayerInput(PlayerInput newPlayerInput)
+    {
+        if(playerInput == null)
+        {
+            //古いPlayerInputのリスナーを解除
+            playerInput.actions.FindActionMap("Player").FindAction("Pause").performed -= OnPause;
+        }
+
+        playerInput = newPlayerInput;
+        if(playerInput != null)
+        {
+            InputAction pauseAction = playerInput.actions.FindActionMap("Player").FindAction("Pause");
+            if(pauseAction != null)
+            {
+                pauseAction.performed += OnPause;
+            }
         }
     }
 
     #endregion
 
-    public void OnPausu(InputAction.CallbackContext context)
+    public void OnPause(InputAction.CallbackContext context)
     {
 
         // Performedフェーズの判定を行う

--- a/Assets/Project/Script/MainScene/PauseManager.cs
+++ b/Assets/Project/Script/MainScene/PauseManager.cs
@@ -50,15 +50,6 @@ public class PauseManager : MonoBehaviour
                 Canvas.SetActive(false);  //取得してから非アクティブに変更
             }
 
-            GameObject player = GameObject.FindWithTag("Player");
-            if(player != null)
-            {
-                PlayerInput newplayerInput = player.GetComponent<PlayerInput>();
-                if(newplayerInput != null)
-                {
-                       
-                }
-            }
         }
     }
 

--- a/Assets/Project/design/MainScene/Player/Player.prefab
+++ b/Assets/Project/design/MainScene/Player/Player.prefab
@@ -4900,11 +4900,11 @@ MonoBehaviour:
   UltStay: {fileID: 542657564707576506}
   particle: {fileID: 9013031806884710724}
   _ultTime: 5
+  UltChargeTime: 25
   _damegeULT: 50
   _boss: {fileID: 0}
   _bossCenter: {fileID: 0}
   _mobCounter: 0
-  prevMobCounter: 0
   isULT: 0
   _hold: {fileID: -5047846092849895973, guid: 289c1b55c9541489481df5cc06664110, type: 3}
 --- !u!114 &6803324902184924405
@@ -4924,6 +4924,8 @@ MonoBehaviour:
   _invincibilityTime: 2
   _damageImg: {fileID: 0}
   _blinkSpeed: 10
+  _playerBlinkSpeed: 0.2
+  _playerRenderers: []
 --- !u!114 &506543896210513844
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -5003,13 +5005,13 @@ MonoBehaviour:
     m_ActionName: Player/ULTAttack
   - m_PersistentCalls:
       m_Calls:
-      - m_Target: {fileID: 0}
-        m_TargetAssemblyTypeName: 
-        m_MethodName: 
-        m_Mode: 1
+      - m_Target: {fileID: 1238605832036620193, guid: 0824162a52a74704c9a39d5af1527554, type: 3}
+        m_TargetAssemblyTypeName: PauseManager, Assembly-CSharp
+        m_MethodName: OnPause
+        m_Mode: 0
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
-          m_ObjectArgumentAssemblyTypeName: 
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
           m_IntArgument: 0
           m_FloatArgument: 0
           m_StringArgument: 


### PR DESCRIPTION
Fix:Pause画面

Pauseの修正を行いました。
PauseManagerのシングルトンを削除し、ManagerオブジェクトではなくMainAdminに
スクリプトをアタッチしています。これによりシーンを移動してもInputが外れること
がありません。
それに伴い、ManagerプレハブからPauseManagerを削除しました。